### PR TITLE
[홍요한] sprint3

### DIFF
--- a/css/auth.css
+++ b/css/auth.css
@@ -90,4 +90,27 @@
 
 .inp_box input[type="password"]#password_confirm{
   background-image:url(../img/btn_visibility_on_24px.svg);
-} 
+}
+
+
+
+@media screen and (max-width: 1199px){
+
+  /* 테블릿 영역 */
+  html {
+    font-size: 56.25%; /* 1rem = 9px */
+  }
+}
+
+@media screen and (max-width: 767px){
+  /* 모바일 영역 */
+  html {
+    font-size: 50%; /* 1rem = 8px */
+  }
+  #cnt.login_area{
+    padding:0 16px;
+  }
+  .login_area .login_wrap{
+    max-width:400px;
+  }
+}

--- a/css/auth.css
+++ b/css/auth.css
@@ -1,7 +1,9 @@
-
-/* login.html style */
+@import url("reset.css");
+@import url("variables.css");
+@import url("common.css");
 
 #cnt.login_area{
+  margin-top:7rem;
   display:flex;
   justify-content: center;
   align-items: center;
@@ -10,7 +12,7 @@
 
 
 .inp_box input[type="password"]{
-  background:#F3F4F6 url(../img/btn_visibility_off_24px.svg) no-repeat center right 15px;
+  background:var(--color-secondary100) url(../img/btn_visibility_off_24px.svg) no-repeat center right 15px;
   padding-right:54px;
 }
 
@@ -40,7 +42,7 @@
   border-radius: 0.8rem;
   align-items:center;
   justify-content: space-between;
-  color: #1F2937;
+  color: var(--color-secondary800);
   font-weight: 500;
   
 }
@@ -71,12 +73,12 @@
   gap:1rem;
   font-size:1.4rem;
   font-weight:500;
-  color:#1F2937;
+  color:var(--color-secondary800);
   justify-content: center;
   align-items: center;
 }
 .login_area .signup_desc .signup_link{
-  color:#3692FF;
+  color:var(--color-primary100);
   font-size:1.4rem;
   font-weight:500;
 }
@@ -85,3 +87,7 @@
 .login_area .signup_desc .signup_link:focus{
   text-decoration:underline;
 }
+
+.inp_box input[type="password"]#password_confirm{
+  background-image:url(../img/btn_visibility_on_24px.svg);
+} 

--- a/css/common.css
+++ b/css/common.css
@@ -1,4 +1,3 @@
-/* Common */
 .btn_box{
   margin-top:3rem;
 }
@@ -21,10 +20,10 @@
 .btn.large{height:5.6rem; padding:0 3rem;font-size:2rem;}
 .btn.full{width:100%;}
 
-.bg_primary_100{background:#3692ff;}
-.bg_primary_200{background:#1967d6;}
-.bg_primary_300{background:#1251aa}
-.bg_secondary_400{background:#9ca3af;}
+.bg_primary_100{background:var(--color-primary100);}
+.bg_primary_200{background:var(--color-primary200);}
+.bg_primary_300{background:var(--color-primary300)}
+.bg_secondary_400{background:var(--color-secondary400);}
 
 .inner{
   width:110rem;
@@ -41,7 +40,7 @@
 }
 
 .inp_box>label{
-  color:#1F2937;
+  color:var(--color-secondary800);
   font-size:1.8rem;
   font-weight:bold;
 }
@@ -53,8 +52,8 @@
   width:100%;
   min-width:10rem;
   height:5.6rem;
-  background:#F3F4F6;
+  background:var(--color-secondary100);
   border-radius:1.2rem;
   padding:0 1.5rem;
-  color:#1F2937;
+  color:var(--color-secondary800);
 }

--- a/css/common.css
+++ b/css/common.css
@@ -57,3 +57,4 @@
   padding:0 1.5rem;
   color:var(--color-secondary800);
 }
+

--- a/css/layout.css
+++ b/css/layout.css
@@ -11,6 +11,7 @@
   display:flex;
   background:#fff;
   justify-content:center;
+  z-index:99999999;
 }
 .header_inner{
   display:flex;
@@ -50,7 +51,7 @@
 }
 .footer .footer_inner{
   width:112rem;
-  padding-top:2rem;
+  padding-top:3.2rem;
 }
 .footer .footer_inner .footer_list{
   display:flex;

--- a/css/layout.css
+++ b/css/layout.css
@@ -30,7 +30,7 @@
 }
 .login_box .login_btn{
   display:inline-flex;
-  background:#3692ff;
+  background:var(--color-primary100);
   width:12.8rem;
   height:4.8rem;
   padding:0 1rem;
@@ -45,7 +45,7 @@
 .footer{
   display:flex;
   height:16rem;
-  background:#111827;
+  background:var(--color-secondary900);
   justify-content: center;
 }
 .footer .footer_inner{
@@ -59,14 +59,14 @@
 }
 
 .footer .footer_list>li{
-  color:#9CA3AF;
+  color:var(--color-secondary400);
 }
 .footer_list .footer_nav{
   display: flex;
   gap:3rem;
 }
 .footer_nav>li>a{
-  color:#E5E7EB;
+  color:var(--color-secondary200);
 }
 
 .sns_list{

--- a/css/reset.css
+++ b/css/reset.css
@@ -3,7 +3,7 @@
   padding:0;
   margin:0;
   word-break: keep-all;
-  color:#374151;
+  color:var(--color-secondary700);
 }
 
 ul,ol,li{

--- a/css/signup.css
+++ b/css/signup.css
@@ -1,6 +1,0 @@
-
-/* signup.html style */
-
-.inp_box input[type="password"]#password_confirm{
-  background-image:url(../img/btn_visibility_on_24px.svg);
-} 

--- a/css/style.css
+++ b/css/style.css
@@ -122,3 +122,121 @@ section[class^="sec"]:not(.sec01).sec03 .info_box{
   font-weight:bold;
   line-height:1.4;
 }
+
+
+@media screen and (max-width: 1199px){
+
+  /* 테블릿 영역 */
+  html {
+    font-size: 56.25%; /* 1rem = 9px */
+  }
+
+  .inner{
+    width:auto;
+    padding:0 24px;
+  }
+  .btn.large{
+    max-width:36rem;
+  }
+  .header_inner{
+    padding: 0 24px;
+  }
+  .sec01{
+    height:auto;
+    min-height:771px;
+  }
+  .sec01>.inner{
+    position:relative;
+    width:100%;
+    padding-top:calc(771 / 744 * 100%);
+    background:url(../img/img_home_top.svg) no-repeat bottom 0 center / contain;
+    background-color:#CFE5FF;
+  }
+  .sec01 .visual_box{
+    position:absolute;
+    width:100%;
+    top: 84px;
+    left:50%;
+    margin-bottom:0;
+    padding:0 24px;
+    transform:translateX(-50%);
+    text-align:center;
+  }
+  .sec01 .visual_box h2{
+    width:auto;
+  }
+
+  section[class^="sec"]:not(.sec01):not(.sec05){
+    margin:2.4rem 0 5.2rem;
+  }
+
+  section[class^="sec"]:not(.sec01) .info_box{
+    width: 100%;
+    height: auto;
+    padding:0;
+    padding-top: calc(524 / 696 * 100%);
+    background-position: top center;
+    background-size: contain;
+  }
+  section[class^="sec"]:not(.sec01) .info_box .tit{
+    margin-top:2.4rem;
+  }
+
+  section[class^="sec"]:not(.sec01).sec03 .info_box{
+    padding: 0;
+    padding-top: calc(524 / 696 * 100%);
+    background-position: top center;
+  }
+
+  .sec05{
+    height:auto;
+    margin-top:5.6rem;
+  }
+  .sec05 .inner{
+    position:relative;
+    width: 100%;
+    padding: 0 24px;
+    padding-top: calc(927 / 744 * 100%);
+    background-position: bottom 0 center;
+    background-size: contain;
+  }
+  .sec05 .inner .brand_box{
+    position:absolute;
+    display:block;
+    width:100%;
+    padding:0 10px;
+    left:50%;
+    transform:translateX(-50%);
+    top:20rem;
+    text-align:center;
+  }
+  .footer .footer_inner{
+    width:100%;
+    padding:0 24px;
+    padding-top:3.2rem;
+  }
+  .footer .footer_inner .footer_list{
+    gap:6.4rem;
+  }
+}
+
+@media screen and (max-width: 767px){
+  /* 모바일 영역 */
+  html {
+    font-size: 50%; /* 1rem = 8px */
+  }
+  .header_inner{
+    padding: 0 16px;
+  }
+  .footer .footer_inner{
+    position:relative;
+  }
+  .footer .footer_list>li:first-child{
+    position:absolute;
+    bottom:3rem;
+  }
+  .sec05 .inner .brand_box{
+    top: 12rem;
+  }
+}
+

--- a/css/style.css
+++ b/css/style.css
@@ -2,8 +2,6 @@
 @import url("variables.css");
 @import url("common.css");
 @import url("layout.css");
-@import url("login.css");
-@import url("signup.css");
 
 
 /* MAIN */
@@ -41,7 +39,7 @@
   font-size:4rem;
   font-weight: bold;
   line-height:1.4;
-  color:#374151;
+  color:var(--color-secondary700);
 }
 .sec01 .visual_box a{
   width:100%;
@@ -72,14 +70,14 @@ section[class^="sec"]:not(.sec01) .info_box{
   justify-content:center;
 }
 section[class^="sec"]:not(.sec01) .info_box .tit{
-  color:#3692ff;
+  color:var(--color-primary100);
   font-size:1.8rem;
   line-height:2.6rem;
   font-weight: 800;
 } 
 section[class^="sec"]:not(.sec01) .info_box h2{
   margin:1rem 0 2rem;
-  color:#374151;
+  color:var(--color-secondary700);
   font-size:4rem;
   font-weight:bold;
   line-height:1.4;
@@ -123,21 +121,4 @@ section[class^="sec"]:not(.sec01).sec03 .info_box{
   font-size:4rem;
   font-weight:bold;
   line-height:1.4;
-}
-
-
-
-@media (max-width:767px){
-  /* 모바일 */
-  html { font-size: 50.8%; } /* 13px */
-}
-
-@media (max-width:1199px){
-  /* 테블릿 */
-  html { font-size: 54.7%; } /* 14px */
-}
-
-@media (min-width: 1120px){
-  /* 데스크탑 */
-  body { font-size: 1.6rem; } /* 16px */
 }

--- a/css/variables.css
+++ b/css/variables.css
@@ -1,13 +1,17 @@
 :root{
-  --color-gray900: #111827;
-  --color-gray800: #1F2937;
-  --color-gray700: #374151;
-  --color-gray600: #4B5563;
-  --color-gray500: #6B7280;
-  --color-gray400: #9CA3AF;
-  --color-gray200: #E5E7EB;
-  --color-gray100: #F3F4F6;
-  --color-gray50: #F9FAFB;
-  --color-blue: #3692FF;
+  --color-secondary900: #111827;
+  --color-secondary800: #1F2937;
+  --color-secondary700: #374151;
+  --color-secondary600: #4B5563;
+  --color-secondary500: #6B7280;
+  --color-secondary400: #9CA3AF;
+  --color-secondary300: #D1D5DB;
+  --color-secondary200: #E5E7EB;
+  --color-secondary100: #F3F4F6;
+  --color-secondary50: #F9FAFB;
+  --color-primary100: #3692FF;
+  --color-primary200: #1967D6;
+  --color-primary300: #1251AA;
+  --color-error: #F74747;
 }
 

--- a/index.html
+++ b/index.html
@@ -3,9 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta property="og:title" content="판다마켓" />
+    <meta property="og:title" content="판다 마켓" />
     <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
-    <meta property="og:url" content="https://hongyohan.netlify.app/mission1/" />
+    <meta property="og:url" content="https://hongyohan.netlify.app/" />
+    <meta property="og:image" content="https://hongyohan.netlify.app/img/logo.svg" />
+    <meta property="og:type" content="website" />
     <link rel="stylesheet" href="css/style.css" />
     <title>판다마켓</title>
   </head>

--- a/index.html
+++ b/index.html
@@ -36,7 +36,11 @@
             <div class="info_box">
               <span class="tit">Hot item</span>
               <h2>인기 상품을 확인해 보세요</h2>
-              <p>가장 HOT한 중고거래 물품을 판다 마켓에서 확인해 보세요</p>
+              <p>
+                가장 HOT한 중고거래 물품을
+                <br />
+                판다 마켓에서 확인해 보세요
+              </p>
             </div>
           </div>
         </section>
@@ -45,7 +49,11 @@
             <div class="info_box">
               <span class="tit">Search</span>
               <h2>구매를 원하는 상품을 검색하세요</h2>
-              <p>구매하고 싶은 물품은 검색해서 쉽게 찾아보세요</p>
+              <p>
+                구매하고 싶은 물품은 검색해서
+                <br />
+                쉽게 찾아보세요
+              </p>
             </div>
           </div>
         </section>
@@ -54,7 +62,11 @@
             <div class="info_box">
               <span class="tit">Register</span>
               <h2>판매를 원하는 상품을 등록하세요</h2>
-              <p>어떤 물건이든 판매하고 싶은 상품을쉽게 등록하세요</p>
+              <p>
+                어떤 물건이든 판매하고 싶은 상품을
+                <br />
+                쉽게 등록하세요
+              </p>
             </div>
           </div>
         </section>

--- a/login.html
+++ b/login.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="판다 마켓" />
     <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
-    <meta property="og:url" content="/" />
+    <meta property="og:url" content="https://hongyohan.netlify.app/" />
+    <meta property="og:image" content="https://hongyohan.netlify.app/img/logo.svg" />
+    <meta property="og:type" content="website" />
     <link rel="stylesheet" href="css/auth.css" />
     <title>로그인 | 판다마켓</title>
   </head>

--- a/login.html
+++ b/login.html
@@ -6,7 +6,7 @@
     <meta property="og:title" content="판다 마켓" />
     <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
     <meta property="og:url" content="/" />
-    <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="css/auth.css" />
     <title>로그인 | 판다마켓</title>
   </head>
   <body>
@@ -28,18 +28,18 @@
             <div class="btn_box">
               <button type="submit" class="btn round large bg_primary_100 full">로그인</button>
             </div>
-            <div class="easy_login_box">
-              간편 로그인하기
-              <div class="sns_login_box">
-                <a href="#;" class="google_login blind">구글로 로그인하기</a>
-                <a href="#;" class="kakao_login blind">카카오톡으로 로그인하기</a>
-              </div>
-            </div>
-            <p class="signup_desc">
-              판다마켓이 처음이신가요?
-              <a href="signup.html" class="signup_link">회원가입</a>
-            </p>
           </form>
+          <div class="easy_login_box">
+            간편 로그인하기
+            <div class="sns_login_box">
+              <a href="#;" class="google_login blind">구글로 로그인하기</a>
+              <a href="#;" class="kakao_login blind">카카오톡으로 로그인하기</a>
+            </div>
+          </div>
+          <p class="signup_desc">
+            판다마켓이 처음이신가요?
+            <a href="signup.html" class="signup_link">회원가입</a>
+          </p>
         </div>
       </main>
     </div>

--- a/signup.html
+++ b/signup.html
@@ -6,7 +6,7 @@
     <meta property="og:title" content="판다 마켓" />
     <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
     <meta property="og:url" content="/" />
-    <link rel="stylesheet" href="css/style.css" />
+    <link rel="stylesheet" href="css/auth.css" />
     <title>회원가입 | 판다마켓</title>
   </head>
   <body>
@@ -36,18 +36,18 @@
             <div class="btn_box">
               <button type="submit" class="btn round large bg_primary_100 full">회원가입</button>
             </div>
-            <div class="easy_login_box">
-              간편 로그인하기
-              <div class="sns_login_box">
-                <a href="#;" class="google_login blind">구글로 로그인하기</a>
-                <a href="#;" class="kakao_login blind">카카오톡으로 로그인하기</a>
-              </div>
-            </div>
-            <p class="signup_desc">
-              이미 회원이신가요?
-              <a href="login.html" class="signup_link">로그인</a>
-            </p>
           </form>
+          <div class="easy_login_box">
+            간편 로그인하기
+            <div class="sns_login_box">
+              <a href="#;" class="google_login blind">구글로 로그인하기</a>
+              <a href="#;" class="kakao_login blind">카카오톡으로 로그인하기</a>
+            </div>
+          </div>
+          <p class="signup_desc">
+            이미 회원이신가요?
+            <a href="signup.html" class="signup_link">로그인</a>
+          </p>
         </div>
       </main>
     </div>

--- a/signup.html
+++ b/signup.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="판다 마켓" />
     <meta property="og:description" content="일상의 모든 물건을 거래해보세요" />
-    <meta property="og:url" content="/" />
+    <meta property="og:url" content="https://hongyohan.netlify.app/" />
+    <meta property="og:image" content="https://hongyohan.netlify.app/img/logo.svg" />
+    <meta property="og:type" content="website" />
     <link rel="stylesheet" href="css/auth.css" />
     <title>회원가입 | 판다마켓</title>
   </head>


### PR DESCRIPTION
## url: https://hongyohan.netlify.app/

## 요구사항

### 기본

#### 브라우저에 현재 보이는 화면의 영역(viewport) 너비를 기준으로 분기되는 반응형 디자인을 적용합니다.
- [x] PC: 1200px 이상
- [x] Tablet: 768px 이상 ~ 1199px 이하
- [x] Mobile: 375px 이상 ~ 767px 이하
- [x] 375px 미만 사이즈의 디자인은 고려하지 않습니다

#### 랜딩 페이지
- [x] Tablet 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 24px, “로그인” 버튼 오른쪽 여백 24px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] Mobile 사이즈로 작아질 때 “판다마켓” 로고의 왼쪽에 여백 16px, “로그인” 버튼 오른쪽 여백 16px을 유지할 수 있도록 “판다마켓” 로고와 “로그인" 버튼의 간격이 가까워집니다.
- [x] 화면 영역이 줄어들면 “Privacy Policy”, “FAQ”, “codeit-2024”이 있는 영역과 SNS 아이콘들이 있는 영역의 간격이 줄어듭니다.

#### 로그인, 회원가입 페이지 공통
- [x] Tablet 사이즈에서 내부 디자인은 PC사이즈와 동일합니다.
- [x] Mobile 사이즈에서 좌우 여백 16px 제외하고 내부 요소들이 너비를 모두 차지합니다.
- [x] Mobile 사이즈에서 내부 요소들의 너비는 기기의 너비가 커지는 만큼 커지지만 400px을 넘지 않습니다.


### 심화

- [x] 페이스북, 카카오톡, 디스코드, 트위터 등 SNS에서 Linkbrary 랜딩 페이지(“/”) 공유 시 좌측 예시와 같은 미리보기를 볼 수 있도록 랜딩 페이지 메타 태그를 설정해 주세요.
- [x] 미리보기에서 제목은 “판다 마켓”, 설명은 “일상의 모든 물건을 거래해보세요”로 설정합니다.
- [x] 주소와 이미지는 자유롭게 설정하세요.


## 주요 변경사항

- 랜딩, 로그인, 회원가입 페이지를 반응형 페이지로 변경


## 스크린샷

### 테블릿
<img width="734" height="4046" alt="image" src="https://github.com/user-attachments/assets/1ca90aec-d30f-4920-a55c-4718c0ed8384" />

### 모바일
<img width="500" height="3226" alt="image" src="https://github.com/user-attachments/assets/bb3a8f26-3191-443b-b7e2-f7e394aefb17" />
<img width="500" height="966" alt="image" src="https://github.com/user-attachments/assets/65734832-be8b-4db1-bdc6-bbeff762628e" />
<img width="500" height="966" alt="image" src="https://github.com/user-attachments/assets/d375fafd-1e3b-477e-87d9-24dd24673dee" />



## 주강사님에게
- 백그라운드 이미지들을 calc로 작성했는데, 이부분에 대해서 주강사님 의견을 듣고싶습니다!
- 잘부탁드립니다!!